### PR TITLE
SLURM: Build conda env each time to ensure compatability

### DIFF
--- a/run_experiment_slurm.sh
+++ b/run_experiment_slurm.sh
@@ -1,42 +1,65 @@
 #!/bin/bash
 
 #SBATCH --job-name="DiPrivML"
-#SBATCH --ntasks=50
+#SBATCH --ntasks=100
 
+echo "Starting script"
 if [[ $# -eq 0 ]] ; then # if called with no arguments
-    echo "Usage: sbatch $0 <DATASET NAME> <CONDA ENV>"
+    echo "Usage: sbatch $0 [-s] <DATASET NAME>"
+    echo "	-s: saves new sample of dataset to data/ directory"
     exit 1
 fi
 
-DATASET=$1
+if [ $1 == '-s' ]; then
+	DATASET=$2
+	SAVE_DATA=true
+else
+	DATASET=$1
+	SAVE_DATA=false
+fi
+
 ATTACK_PY=attack.py
 
+echo "Loading modules"
 source /etc/profile.d/modules.sh
 module load anaconda3
 module load parallel
-source activate $2
+
+# Make sure conda environment has dependencies
+echo "Creating conda environment"
+conda env remove -y -n slurm || true
+conda create -n slurm || true
+source activate slurm
+conda install -y pip
+conda install -y python
+while read r; do
+	pip install $r
+done <requirements.txt
 
 # flags for compatibility between tensorflow and theano
 export KMP_DUPLICATE_LIB_OK=TRUE
 export THEANO_FLAGS=device=cpu
 
-python attack.py $DATASET --save_data=1
+if [ "$SAVE_DATA" = true ]; then
+	echo "Filling data/ directory"
+	python $ATTACK_PY $DATASET --save_data=1
+fi
 
-# `parallel` will run the quoted command, replacing each {n} with each value on
+echo "Beginning experiment"
+# parallel will run the quoted command, replacing each {n} with each value on
 # the n-th line starting with ":::" exactly as if it were a nested for-loop.
 # The start-times, durations, and commands of tasks are stored in joblog.txt.
-parallel -j $SLURM_NTASKS --joblog joblog.txt \
+parallel -j $SLURM_NTASKS --joblog joblog.txt --ungroup \
     "srun --exclusive -N1 -n1 python $ATTACK_PY $DATASET \
+    --target_privacy='grad_pert' \
     --target_model={1} \
     --target_l2_ratio={2} \
-    --target_privacy='grad_pert' \
     --target_dp={3} \
     --target_epsilon={4} \
-    --run={5}" \
-    ::: 'softmax' 'nn' \
-    :::+ '1e-5' '1e-4' \
-    # '+' means we get (softmax, 1e-5) and (nn, 1e-4) vs. all combinations
-    ::: 'dp' 'adv_cmp' 'rdp' 'zcdp' \
-    ::: 0.01 0.05 0.1 0.5 1.0 5.0 10.0 50.0 100.0 500.0 1000.0 \
-    ::: 1 2 3 4 5
+    --run={5}" ::: 'softmax' 'nn' :::+ '1e-5' '1e-4' ::: 'dp' 'rdp' ::: 0.5 1.0 5.0 10.0 50.0 ::: 1 2 3 4 5
+parallel -j 20 "srun --exclusive -N1 -n1 python $ATTACK_PY $DATASET \
+    --target_privacy='no_privacy' \
+    --target_model={1} \
+    --target_l2_ratio={2} \
+    --run={3}" ::: 'softmax' 'nn' :::+ '1e-5' '1e-4' ::: 1 2 3 4 5
 echo done


### PR DESCRIPTION
The slurm script stopped working. I changed it to reinstall all the dependencies every time it runs, which works. There might be a better way to do this, but it seems important that the packages are installed on the same computer where they'll be used