### PR TITLE
Adds self parameter to "normalizeDataset" function

### DIFF
--- a/extra/preprocess_dataset.py
+++ b/extra/preprocess_dataset.py
@@ -113,9 +113,9 @@ class PreprocessDataset:
             self.preprocess_all_census()
         elif self.dataset_name == 'texas_100_v2':
             self.preprocess_texas()
-    
-    
-    def normalizeDataset(X):
+
+
+    def normalizeDataset(self, X):
         mods = np.linalg.norm(X, axis=1)
         return X / mods[:, np.newaxis]
     


### PR DESCRIPTION
In order to run the preprocessing for the purchase_100 dataset on python 3.10.8 the self parameter is needed in the PreprocessDataset's normalizeDataset function.